### PR TITLE
isCtrlClicked debería funcionar para Cmd en MacOS

### DIFF
--- a/src/components/gs-board/script.coffee
+++ b/src/components/gs-board/script.coffee
@@ -214,7 +214,7 @@ Polymer
     table.length - 1 - rowIndex
 
   isCtrlPressed: ->
-    @$.keyTracker.isPressed "Control"
+    (@$.keyTracker.isPressed "Control") or ((@$.keyTracker.isPressed "Meta") and (/Mac/.test navigator.platform))
 
   isShiftPressed: ->
     @$.keyTracker.isPressed "Shift"


### PR DESCRIPTION
Cmd es la tecla utilizada en MacOS para reemplazar Ctrl. Más aún al empaquetar una app con Electron y presionar Ctrl+Click en MacOS, la acción es ignorada, y no se levanta ningún trigger. Cmd+Click debería actuar de la misma forma que Ctrl+Click en otros OS, por lo que es necesario detectar ese caso como especial. Cmd es detectado por JS como "Meta".

Esto arregla un bug en MacOS al empaquetar la App Gobstones-Web, en donde es imposible modificar la posición inicial del cabezal en el tablero pues Ctrl es ignorado, y Cmd no es mirado.